### PR TITLE
Fix: Add storage.yml for Render Deployment

### DIFF
--- a/web/config/environments/production.rb
+++ b/web/config/environments/production.rb
@@ -57,6 +57,9 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
+  # Store uploaded files on the local file system (see config/storage.yml for options).
+  config.active_storage.service = :render
+
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com

--- a/web/config/storage.yml
+++ b/web/config/storage.yml
@@ -1,0 +1,11 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+render:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>


### PR DESCRIPTION
Resolves deployment failure due to missing Active Storage configuration.

Changes:
- Adds `config/storage.yml` with default disk storage configuration.
- Explicitly sets `config.active_storage.service = :render` in `production.rb`.

This fixes the `RuntimeError: Couldn't find Active Storage configuration` error during boot.